### PR TITLE
Make subProcess() return the created ChildProcess

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -57,9 +57,9 @@ const spawnSubProcessOnWindows = (owner: string, command: string, showOutput: bo
 
 export const subProcess = (owner: string, command: string, showOutput: boolean) => {
   if (process.platform === 'win32') {
-    spawnSubProcessOnWindows(owner, command, showOutput);
+    return spawnSubProcessOnWindows(owner, command, showOutput);
   } else {
-    spawnSubProcess(owner, command, showOutput);
+    return spawnSubProcess(owner, command, showOutput);
   }
 };
 


### PR DESCRIPTION
Both `spawnSubProcess()` and `spawnSubProcessOnWindows()` return the ChildProcess that's created, so ` subProcess()` should also return it.